### PR TITLE
fix: fallback to process.env when window is not available

### DIFF
--- a/src/getEnvConfig.ts
+++ b/src/getEnvConfig.ts
@@ -3,8 +3,11 @@ export interface EnvConfig {
 }
 
 export function getEnvConfig<T extends keyof EnvConfig>(key: keyof EnvConfig): EnvConfig[T] | undefined {
-  const { env } = window as unknown as { env: EnvConfig };
-  const config = env || {};
-
-  return config[key];
+  const _window = global.window as unknown as { env?: EnvConfig };
+  if (_window?.env) {
+    return _window.env[key];
+  }
+  if (global.process?.env) {
+    return global.process.env[key];
+  }
 }

--- a/test/getEnvConfig.test.ts
+++ b/test/getEnvConfig.test.ts
@@ -1,15 +1,22 @@
 import { EnvConfig, getEnvConfig } from '~/getEnvConfig';
 
 describe('getEnvConfig', () => {
+  const env = process.env;
+
   beforeEach(() => {
     jest.resetModules();
     delete (window as unknown as { env?: EnvConfig }).env;
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    process.env = env;
   });
 
   it('should get a config value from window.env', () => {
     // given
     const config: EnvConfig = {
-      BACKEND_URL: 'http://localhost:4000',
+      BACKEND_URL: 'http://localhost:4000/window',
     };
     (window as unknown as { env?: EnvConfig }).env = config;
 
@@ -18,6 +25,17 @@ describe('getEnvConfig', () => {
 
     // then
     expect(configBackendUrl).toStrictEqual(config.BACKEND_URL);
+  });
+
+  it('should get a config value from process.env', () => {
+    // given
+    process.env.BACKEND_URL = 'http://localhost:4000/process';
+
+    // when
+    const configBackendUrl = getEnvConfig('BACKEND_URL');
+
+    // then
+    expect(configBackendUrl).toStrictEqual(process.env.BACKEND_URL);
   });
 
   it('should return undefined when a config value is not set', () => {


### PR DESCRIPTION
Closes #5 