### PR TITLE
fix: prevent build error when assets/ does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Instead of building your frontend on startup,
 you can use a config template like the one above and populate it using `envsubst`:
 
 ```Dockerfile
-CMD ["/bin/sh", "-c", "envsubst < ./dist/assets/env-config.template.js > ./dist/assets/env-config.js && exec nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", "envsubst < ./dist/env-config.template.js > ./dist/env-config.js && exec nginx -g 'daemon off;'"]
 ```
 
 `@geprog/vite-plugin-env-config` generates the required template from a list of variable names and provides the already populated file via the dev-server during development.

--- a/src/envConfig.ts
+++ b/src/envConfig.ts
@@ -38,7 +38,7 @@ export function envConfig(userOptions: Partial<EnvConfigOptions> = {}): Plugin {
       const envConfigContent = createEnvConfigContent(userOptions.variables || [], false);
 
       server.middlewares.use((req, res, next) => {
-        if (req.url === '/assets/env-config.js') {
+        if (req.url === '/env-config.js') {
           // standard headers
           res.setHeader('Content-Type', 'application/javascript; charset=utf-8');
           res.setHeader('Cache-Control', 'no-cache');
@@ -55,12 +55,12 @@ export function envConfig(userOptions: Partial<EnvConfigOptions> = {}): Plugin {
     closeBundle() {
       const templateContent = createEnvConfigContent(userOptions.variables || [], true);
 
-      const TEMPLATE_PATH = path.join(root, 'dist', 'assets', 'env-config.template.js');
+      const TEMPLATE_PATH = path.join(root, 'dist', 'env-config.template.js');
       fs.writeFileSync(TEMPLATE_PATH, templateContent, 'utf8');
     },
 
     transformIndexHtml(html) {
-      return html.replace('</head>', '<script src="/assets/env-config.js"></script></head>');
+      return html.replace('</head>', '<script src="/env-config.js"></script></head>');
     },
   };
 }


### PR DESCRIPTION
BREAKING CHANGE: the generated template can now be found in `dist/env-config.template.js`. You may need to adjust your envsubst parameters