### PR TITLE
fix: export getEnvConfig separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export default {
 To access the environment variables use the built-in getter:
 
 ```ts
-import { getEnvConfig } from '@geprog/vite-plugin-env-config';
+import { getEnvConfig } from '@geprog/vite-plugin-env-config/getEnvConfig';
 
 const backendURL = getEnvConfig('BACKEND_URL');
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,16 @@
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
+    },
+    "./getEnvConfig": {
+      "import": "./dist/getEnvConfig.mjs",
+      "require": "./dist/getEnvConfig.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": ["./dist/index.d.ts"],
+      "getEnvConfig": ["./dist/getEnvConfig.d.ts"]
     }
   },
   "main": "./dist/index.js",
@@ -18,7 +28,7 @@
     "/dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --dts --format cjs,esm",
+    "build": "tsup src/index.ts src/getEnvConfig.ts --dts --format cjs,esm",
     "clean": "rm -rf dist/ node_modules/",
     "lint": "eslint --max-warnings 0 .",
     "lint:format": "prettier --check .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,1 @@
-import { envConfig, EnvConfigOptions } from './envConfig';
-import { EnvConfig, getEnvConfig } from './getEnvConfig';
-
-export { EnvConfig, envConfig, EnvConfigOptions, getEnvConfig };
+export { envConfig, EnvConfigOptions } from './envConfig';


### PR DESCRIPTION
Closes #14 

BREAKING CHANGE: the import for getEnvConfig has to be changed to `import { getEnvConfig } from '@geprog/vite-plugin-env-config/getEnvConfig';`