### PR TITLE
fix: export getEnvConfig in index file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ export default {
 To access the environment variables use the built-in getter:
 
 ```ts
-import { getEnvConfig } from '@geprog/vite-plugin-env-config/getEnvConfig';
+import { getEnvConfig } from '@geprog/vite-plugin-env-config';
 
 const backendURL = getEnvConfig('BACKEND_URL');
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { envConfig, EnvConfigOptions } from './envConfig';
+export { getEnvConfig } from './getEnvConfig';


### PR DESCRIPTION
Increases compatibility with environments that can't import `@geprog/vite-plugin-env-config/getEnvConfig`.

This should be possible without problems since we no longer import node internals.