### PR TITLE
fix: remove locked engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "engines": {
-    "pnpm": "7"
+    "pnpm": ">=7"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Setting the engine version of pnpm restricts apps with pnpm version 8 or later to use this library.